### PR TITLE
Build nipkg for each custom device

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -107,3 +107,17 @@ project = '{slsc}'
 target = 'My Computer'
 build_spec = 'Scripting API'
 dependency_target = 'Windows'
+
+[[package]]
+type = 'nipkg'
+payload_dir = 'Source\Built\Routing and Faulting'
+install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices'
+control_file = 'control_routing_faulting'
+package_output_dir = 'Source\Built'
+
+[[package]]
+type = 'nipkg'
+payload_dir = 'Source\Built\SLSC Switch'
+install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\SLSC Plugins\Modules'
+control_file = 'control_slsc_switch'
+package_output_dir = 'Source\Built'

--- a/control_routing_faulting
+++ b/control_routing_faulting
@@ -1,0 +1,14 @@
+Package: ni-routing-and-faulting-{veristand_version}-support
+Version: {nipkg_version}
+Architecture: windows_all
+Maintainer: National Instruments <support@ni.com>
+XB-Plugin: file
+Description: Provides support for the Routing and Faulting custom device for NI VeriStand {veristand_version}.
+XB-Eula: eula-ni-standard
+Priority: standard
+Homepage: http://www.ni.com
+XB-LanguageSupport: en
+XB-UserVisible: yes
+Section: Add-Ons
+XB-DisplayVersion: {display_version}
+XB-DisplayName: NI Routing and Faulting for VeriStand {veristand_version}

--- a/control_slsc_switch
+++ b/control_slsc_switch
@@ -1,0 +1,14 @@
+Package: ni-slsc-switch-{veristand_version}-support
+Version: {nipkg_version}
+Architecture: windows_all
+Maintainer: National Instruments <support@ni.com>
+XB-Plugin: file
+Description: Provides support for the SLSC Switch custom device for NI VeriStand {veristand_version}.
+XB-Eula: eula-ni-standard
+Priority: standard
+Homepage: http://www.ni.com
+XB-LanguageSupport: en
+XB-UserVisible: yes
+Section: Add-Ons
+XB-DisplayVersion: {display_version}
+XB-DisplayName: NI SLSC Switch for VeriStand {veristand_version}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Builds a separate `.nipkg` file for the Routing and Faulting and the SLSC Switch custom devices.

### Why should this Pull Request be merged?

The custom devices need to install to separate locations and should be installed through different packages.

**Note**: Ultimately, there should be _RECOMMENDS_ and _REQUIRES_ relationships between the packages, but this is a first pass at getting the packages building so they can be pulled into a feed.

### What testing has been done?

[Built dev branch](http://coordinator/job/VeriStand/job/ni/job/niveristand-routing-and-faulting-custom-device/job/dev%252Fmulti-pkg/2/). Verified each package contains only the correct custom device in the correct install location.

Build output:
![image](https://user-images.githubusercontent.com/29306186/63529879-16b6e180-c4cb-11e9-8f45-26fb4b3dc4e0.png)

