### PR TITLE
Install nipkgs to correct folders

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -111,13 +111,13 @@ dependency_target = 'Windows'
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Built\Routing and Faulting'
-install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices'
+install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Routing and Faulting'
 control_file = 'control_routing_faulting'
 package_output_dir = 'Source\Built'
 
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Built\SLSC Switch'
-install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\SLSC Plugins\Modules'
+install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\SLSC Plugins\Modules\SLSC Switch'
 control_file = 'control_slsc_switch'
 package_output_dir = 'Source\Built'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Installs the nipkg files to the correct folder structure.

### Why should this Pull Request be merged?

Currently, everything gets installed to a top-level folder, which sprinkles files everywhere.

### What testing has been done?

None. Need a release build to validate.
