### PR TITLE
Fix package names to match convention

### DIFF
--- a/control_routing_faulting
+++ b/control_routing_faulting
@@ -1,4 +1,4 @@
-Package: ni-routing-and-faulting-{veristand_version}-support
+Package: ni-routing-and-faulting-veristand-{veristand_version}-support
 Version: {nipkg_version}
 Architecture: windows_all
 Maintainer: National Instruments <support@ni.com>

--- a/control_slsc_switch
+++ b/control_slsc_switch
@@ -1,4 +1,4 @@
-Package: ni-slsc-switch-{veristand_version}-support
+Package: ni-slsc-switch-veristand-{veristand_version}-support
 Version: {nipkg_version}
 Architecture: windows_all
 Maintainer: National Instruments <support@ni.com>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Names the nipkg files according to convention and to be consistent with other custom devices.

### Why should this Pull Request be merged?

Consistency.

### What testing has been done?

None
