### PR TITLE
Build packages for scripting APIs

### DIFF
--- a/Source/Routing and Faulting/Routing and Faulting Custom Device.lvproj
+++ b/Source/Routing and Faulting/Routing and Faulting Custom Device.lvproj
@@ -741,25 +741,33 @@
 				<Property Name="Bld_excludedDirectory[5]" Type="Path">user.lib</Property>
 				<Property Name="Bld_excludedDirectory[5].pathType" Type="Str">relativeToAppDir</Property>
 				<Property Name="Bld_excludedDirectoryCount" Type="Int">6</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Routing and Faulting/Windows/Routing and Faulting Scripting API.llb</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/Routing and Faulting Scripting API</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{4DD6684D-3970-4A6D-A0E8-84ECE828ED70}</Property>
-				<Property Name="Bld_version.build" Type="Int">15</Property>
+				<Property Name="Bld_version.build" Type="Int">21</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Routing and Faulting/Windows/Routing and Faulting Scripting API.llb</Property>
-				<Property Name="Destination[0].type" Type="Str">LLB</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Routing and Faulting Scripting API</Property>
+				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
 				<Property Name="Destination[1].path" Type="Path">../Built/Routing and Faulting/Windows/data</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{B191E2B2-950C-4855-B0CC-92C45D97AECD}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{75D12AC9-7BC0-425E-AD96-E54D2019CF94}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Scripting API/Routing and Faulting Scripting.lvlib</Property>
 				<Property Name="Source[1].Library.allowMissingMembers" Type="Bool">true</Property>
 				<Property Name="Source[1].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[1].type" Type="Str">Library</Property>
-				<Property Name="SourceCount" Type="Int">2</Property>
+				<Property Name="Source[2].destinationIndex" Type="Int">0</Property>
+				<Property Name="Source[2].itemID" Type="Ref">/My Computer/Routing and Faulting System Explorer.lvlib</Property>
+				<Property Name="Source[2].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[2].type" Type="Str">Library</Property>
+				<Property Name="Source[3].destinationIndex" Type="Int">0</Property>
+				<Property Name="Source[3].itemID" Type="Ref">/My Computer/Routing and Faulting Engine.lvlib</Property>
+				<Property Name="Source[3].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[3].type" Type="Str">Library</Property>
+				<Property Name="SourceCount" Type="Int">4</Property>
 			</Item>
 		</Item>
 	</Item>

--- a/Source/SLSC Switch/SLSC Switch Custom Device.lvproj
+++ b/Source/SLSC Switch/SLSC Switch Custom Device.lvproj
@@ -775,19 +775,19 @@
 				<Property Name="Bld_excludedDirectory[4]" Type="Path">/C/ProgramData/National Instruments/InstCache/17.0</Property>
 				<Property Name="Bld_excludedDirectory[5]" Type="Path">/C/Users/nitest/Documents/LabVIEW Data/2017(32-bit)/ExtraVILib</Property>
 				<Property Name="Bld_excludedDirectoryCount" Type="Int">6</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/SLSC Switch/Windows/SLSC Switch Scripting API.llb</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/SLSC Switch Scripting API</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Copy .LLB to NI VeriStand dir.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{B81CE306-DCDF-4D4E-9175-E65843F20A57}</Property>
 				<Property Name="Bld_version.build" Type="Int">11</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/SLSC Switch/Windows/SLSC Switch Scripting API.llb</Property>
-				<Property Name="Destination[0].type" Type="Str">LLB</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/SLSC Switch Scripting API</Property>
+				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
 				<Property Name="Destination[1].path" Type="Path">../Built/SLSC Switch/Windows/data</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{7ACAAD6B-932F-436E-81C3-0AA1F08E52C6}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{F3A0DC39-6461-4BCA-819E-63BCBE33A02C}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Scripting API/SLSC Switch Scripting.lvlib</Property>

--- a/build.toml
+++ b/build.toml
@@ -118,7 +118,7 @@ package_output_dir = 'Source\Built'
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Built\Routing and Faulting Scripting API'
-install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\NI VeriStand\Custom Device Scripting APIs\Routing and Faulting'
+install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Routing and Faulting'
 control_file = 'control_routing_faulting_scripting'
 package_output_dir = 'Source\Built'
 
@@ -132,6 +132,6 @@ package_output_dir = 'Source\Built'
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Built\SLSC Switch Scripting API'
-install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\NI VeriStand\Custom Device Scripting APIs\SLSC Switch'
+install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\SLSC Switch'
 control_file = 'control_slsc_switch_scripting'
 package_output_dir = 'Source\Built'

--- a/build.toml
+++ b/build.toml
@@ -117,7 +117,21 @@ package_output_dir = 'Source\Built'
 
 [[package]]
 type = 'nipkg'
+payload_dir = 'Source\Built\Routing and Faulting Scripting API'
+install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\NI VeriStand\Custom Device Scripting APIs\Routing and Faulting'
+control_file = 'control_routing_faulting_scripting'
+package_output_dir = 'Source\Built'
+
+[[package]]
+type = 'nipkg'
 payload_dir = 'Source\Built\SLSC Switch'
 install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\SLSC Plugins\Modules\SLSC Switch'
 control_file = 'control_slsc_switch'
+package_output_dir = 'Source\Built'
+
+[[package]]
+type = 'nipkg'
+payload_dir = 'Source\Built\SLSC Switch Scripting API'
+install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\NI VeriStand\Custom Device Scripting APIs\SLSC Switch'
+control_file = 'control_slsc_switch_scripting'
 package_output_dir = 'Source\Built'

--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -1,0 +1,14 @@
+Package: ni-routing-and-faulting-veristand-{veristand_version}-labview-support
+Version: {nipkg_version}
+Architecture: windows_all
+Maintainer: National Instruments <support@ni.com>
+XB-Plugin: file
+Description: Provides LabVIEW support for the Routing and Faulting custom device for NI VeriStand {veristand_version}.
+XB-Eula: eula-ni-standard
+Priority: standard
+Homepage: http://www.ni.com
+XB-LanguageSupport: en
+XB-UserVisible: yes
+Section: Add-Ons
+XB-DisplayVersion: {display_version}
+XB-DisplayName: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}

--- a/control_slsc_switch_scripting
+++ b/control_slsc_switch_scripting
@@ -1,0 +1,14 @@
+Package: ni-slsc-switch-veristand-{veristand_version}-labview-support
+Version: {nipkg_version}
+Architecture: windows_all
+Maintainer: National Instruments <support@ni.com>
+XB-Plugin: file
+Description: Provides LabVIEW support for the SLSC Switch custom device for NI VeriStand {veristand_version}.
+XB-Eula: eula-ni-standard
+Priority: standard
+Homepage: http://www.ni.com
+XB-LanguageSupport: en
+XB-UserVisible: yes
+Section: Add-Ons
+XB-DisplayVersion: {display_version}
+XB-DisplayName: NI SLSC Switch LabVIEW Support for VeriStand {veristand_version}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add initial package building for installing the scripting APIs. 

Add two new packages, one per custom device, that install the scripting APIs to vi.lib. The scripting APIs are installed as source, instead of LLBs.

### What does this Pull Request _not_ accomplish?

The exact structure of the scripting APIs is not determined; we will want to fix a dependency inversion in the Routing and Faulting shared library that is pulling in the System Explorer library. This is currently causing the installed files to be nested inside another directory.

### Why should this Pull Request be merged?

We eventually want to install palette and example files; this is the first step.

### What testing has been done?

Built the packages on a dev branch and confirmed they install into vi.lib.
 `\\nirvana\measurements\VeriStandAddons\routing_and_faulting_custom_device\ni\export\dev\lv_integration\Build 7\2017\installer`