### PR TITLE
Rename aliases and disallow renaming/deletion

### DIFF
--- a/Source/Routing and Faulting/Custom Device Routing and Faulting.xml
+++ b/Source/Routing and Faulting/Custom Device Routing and Faulting.xml
@@ -153,9 +153,11 @@
     </Page>
     <Page>
       <Name>
-        <eng>Aliases</eng>
-        <loc>Aliases</loc>
+        <eng>Endpoint Aliases</eng>
+        <loc>Endpoint Aliases</loc>
       </Name>
+      <DisallowRenaming>true</DisallowRenaming>
+      <DeleteProtection>true</DeleteProtection>
       <GUID>58f3342d-82ee-4932-869a-6f49da3049e5</GUID>
       <Glyph>
         <Type>To Common Doc Dir</Type>
@@ -171,6 +173,8 @@
         <eng>Routing Channels</eng>
         <loc>Routing Channels</loc>
       </Name>
+      <DisallowRenaming>true</DisallowRenaming>
+      <DeleteProtection>true</DeleteProtection>
       <GUID>ce8870b5-cb8e-4b52-ac34-5b792fdc2ead</GUID>
       <Glyph>
         <Type>To Common Doc Dir</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Renames `Aliases` section to `Endpoint Aliases` to match the string in the scripting API.
-  Prevents renaming and deletion of `Endpoint Aliases` and `Routing Channels` sections.

### Why should this Pull Request be merged?

Strings should match between the scripting API and users should not be able to delete these sections.

### What testing has been done?

Built and made sure names are correct when adding the custom device and sections cannot be renamed or deleted.
