### PR TITLE
Install examples to `NI VeriStand Custom Devices`

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -152,6 +152,6 @@ package_output_dir = 'Source\Built'
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Built\Scripting Examples'
-install_destination = 'ni-paths-LV{veristand_version}DIR\examples\VeriStand Custom Devices\Routing and Faulting'
+install_destination = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\Routing and Faulting'
 control_file = 'control_examples'
 package_output_dir = 'Source\Built'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Install examples to `NI VeriStand Custom Devices`.

### Why should this Pull Request be merged?

This makes the directory appear adjacent to the existing VeriStand examples.

Requested by @jashnani.

### What testing has been done?

None.