### PR TITLE
Set SLSC chassis type to IP address, from hostname

### DIFF
--- a/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF.nivssdf
+++ b/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF.nivssdf
@@ -195,6 +195,9 @@
 								<Property Name="Password">
 									<String />
 								</Property>
+								<Property Name="Chassis ID Type">
+									<I32>1</I32>
+								</Property>
 							</Properties>
 							<Errors />
 							<Section Name="Modules" TypeGUID="96319964-d29d-4af0-9c60-b1a785679b5f">

--- a/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Diff_Resource.nivssdf
+++ b/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Diff_Resource.nivssdf
@@ -195,6 +195,9 @@
 								<Property Name="Password">
 									<String />
 								</Property>
+								<Property Name="Chassis ID Type">
+									<I32>1</I32>
+								</Property>
 							</Properties>
 							<Errors />
 							<Section Name="Modules" TypeGUID="96319964-d29d-4af0-9c60-b1a785679b5f">

--- a/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Initial_States.nivssdf
+++ b/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Initial_States.nivssdf
@@ -195,6 +195,9 @@
 								<Property Name="Password">
 									<String />
 								</Property>
+								<Property Name="Chassis ID Type">
+									<I32>1</I32>
+								</Property>
 							</Properties>
 							<Errors />
 							<Section Name="Modules" TypeGUID="96319964-d29d-4af0-9c60-b1a785679b5f">

--- a/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Invalid_Switch_Resource.nivssdf
+++ b/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Invalid_Switch_Resource.nivssdf
@@ -195,6 +195,9 @@
 								<Property Name="Password">
 									<String />
 								</Property>
+								<Property Name="Chassis ID Type">
+									<I32>1</I32>
+								</Property>
 							</Properties>
 							<Errors />
 							<Section Name="Modules" TypeGUID="96319964-d29d-4af0-9c60-b1a785679b5f">

--- a/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_No_Routing_Channels.nivssdf
+++ b/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_No_Routing_Channels.nivssdf
@@ -195,6 +195,9 @@
 								<Property Name="Password">
 									<String />
 								</Property>
+								<Property Name="Chassis ID Type">
+									<I32>1</I32>
+								</Property>
 							</Properties>
 							<Errors />
 							<Section Name="Modules" TypeGUID="96319964-d29d-4af0-9c60-b1a785679b5f">

--- a/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Rich_States.nivssdf
+++ b/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Rich_States.nivssdf
@@ -192,6 +192,9 @@
 								<Property Name="Password">
 									<String />
 								</Property>
+								<Property Name="Chassis ID Type">
+									<I32>1</I32>
+								</Property>
 							</Properties>
 							<Errors />
 							<Section Name="Modules" TypeGUID="96319964-d29d-4af0-9c60-b1a785679b5f">

--- a/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Rich_States_Aliases.nivssdf
+++ b/Source/Routing and Faulting/Tests/System/Assets/Switch_and_RaF_Rich_States_Aliases.nivssdf
@@ -192,6 +192,9 @@
 								<Property Name="Password">
 									<String />
 								</Property>
+								<Property Name="Chassis ID Type">
+									<I32>1</I32>
+								</Property>
 							</Properties>
 							<Errors />
 							<Section Name="Modules" TypeGUID="96319964-d29d-4af0-9c60-b1a785679b5f">


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This appears to fix the tests when the SLSC chassis is not in the local configuration.

### Why should this Pull Request be merged?

The tests are currently failing.

### What testing has been done?

These same changes were made during a test run, and fixed the failing tests.