### PR TITLE
Add nipkg dependencies on VeriStand and LabVIEW

### DIFF
--- a/control_examples
+++ b/control_examples
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Routing and Faulting LabVIEW Examples for VeriStand {veristand_version}
-Depends: ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version})
+Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version})

--- a/control_routing_faulting
+++ b/control_routing_faulting
@@ -12,4 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Routing and Faulting for VeriStand {veristand_version}
+Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
 Recommends: ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -12,4 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}
+Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
 Recommends: ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_slsc_switch
+++ b/control_slsc_switch
@@ -12,4 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI SLSC Switch for VeriStand {veristand_version}
+Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_slsc_switch_scripting
+++ b/control_slsc_switch_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version})
+Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version})
 Recommends: ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add dependencies on VeriStand and LabVIEW to the nipkgs.

### Why should this Pull Request be merged?

This prevents installing the packages in environments where they can't be used.

### What testing has been done?

None, currently waiting on a build to test.