### PR TITLE
Mark architecture as windows_x64

### DIFF
--- a/control_custom_device_labview_support_common
+++ b/control_custom_device_labview_support_common
@@ -1,6 +1,6 @@
 Package: ni-veristand-{veristand_version}-custom-device-labview-support-common
 Version: {nipkg_version}
-Architecture: windows_all
+Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides common LabVIEW support for custom devices for NI VeriStand {veristand_version}.

--- a/control_examples
+++ b/control_examples
@@ -1,6 +1,6 @@
 Package: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples
 Version: {nipkg_version}
-Architecture: windows_all
+Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides LabVIEW examples for the Routing and Faulting custom device for NI VeriStand {veristand_version}.

--- a/control_routing_faulting
+++ b/control_routing_faulting
@@ -1,6 +1,6 @@
 Package: ni-routing-and-faulting-veristand-{veristand_version}-support
 Version: {nipkg_version}
-Architecture: windows_all
+Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides support for the Routing and Faulting custom device for NI VeriStand {veristand_version}.

--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -1,6 +1,6 @@
 Package: ni-routing-and-faulting-veristand-{veristand_version}-labview-support
 Version: {nipkg_version}
-Architecture: windows_all
+Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides LabVIEW support for the Routing and Faulting custom device for NI VeriStand {veristand_version}.

--- a/control_slsc_switch
+++ b/control_slsc_switch
@@ -1,6 +1,6 @@
 Package: ni-slsc-switch-veristand-{veristand_version}-support
 Version: {nipkg_version}
-Architecture: windows_all
+Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides support for the SLSC Switch custom device for NI VeriStand {veristand_version}.

--- a/control_slsc_switch_scripting
+++ b/control_slsc_switch_scripting
@@ -1,6 +1,6 @@
 Package: ni-slsc-switch-veristand-{veristand_version}-labview-support
 Version: {nipkg_version}
-Architecture: windows_all
+Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides LabVIEW support for the SLSC Switch custom device for NI VeriStand {veristand_version}.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change package architecture to windows_x64, to align with the VeriStand 2019 and newer package architecture.

### Why should this Pull Request be merged?

VeriStand 2019 and newer are windows_x64 packages, so having the custom device be windows_all is a bit nonsensical (and is causing warnings to be thrown by internal tooling). Changing the package to windows_x64 prevents installation of the custom devices via .nipkg on 32-bit Windows for VeriStand 2018 and older, but this is a niche use case and workarounds are available.

### What testing has been done?

None.
