### PR TITLE
Adding target.ini file

### DIFF
--- a/Source/Routing and Faulting/Scripting/Tests/System/targets.ini
+++ b/Source/Routing and Faulting/Scripting/Tests/System/targets.ini
@@ -1,0 +1,5 @@
+[Supported Targets]
+Windows = localhost
+
+[Active Configuration]
+Platform = Windows


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

It add a target.ini file for the Deploy Scripted System Definition test

### Why should this Pull Request be merged?

Deploy Scripted System Definition is a system test that needs this file.

### What testing has been done?

More than you can imagine = finally got the test to run (and pass) on my VM.
