### PR TITLE
Add targets.ini to SLSC Switch scripting system tests

### DIFF
--- a/Source/SLSC Switch/Scripting/Tests/System/targets.ini
+++ b/Source/SLSC Switch/Scripting/Tests/System/targets.ini
@@ -1,0 +1,5 @@
+[Supported Targets]
+Windows = localhost
+
+[Active Configuration]
+Platform = Windows


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This does the same thing as #194, but for the SLSC Switch scripting system test:
Add a target.ini file for the Deploy Scripted System Definition test

### Why should this Pull Request be merged?

This will execute the auto-test as a system test, as it needs PXI hardware online.

### What testing has been done?

None.
