### PR TITLE
Add build notification

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -160,3 +160,6 @@ payload_dir = 'Source\Shared\Custom Device LabVIEW Common'
 install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs'
 control_file = 'control_custom_device_labview_support_common'
 package_output_dir = 'Source\Built'
+
+[notification]
+type = 'teams'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables build notifications to Microsoft Teams on build failures/fixes.

### Why should this Pull Request be merged?

We want to know when builds fail.

### What testing has been done?

None
