### PR TITLE
Use SLSC IP address instead of hostname in scripting test

### DIFF
--- a/Source/SLSC Switch/Scripting/Tests/System/Assets/Base with 1 SLSC Switch CD.nivssdf
+++ b/Source/SLSC Switch/Scripting/Tests/System/Assets/Base with 1 SLSC Switch CD.nivssdf
@@ -184,7 +184,7 @@
 									<String>SLSC-12001</String>
 								</Property>
 								<Property Name="Chassis ID">
-									<String>VS-Eco-SLSC-12001</String>
+									<String>10.2.207.133</String>
 								</Property>
 								<Property Name="Username">
 									<String>anonymous</String>

--- a/Source/SLSC Switch/Scripting/Tests/System/Assets/config.ini
+++ b/Source/SLSC Switch/Scripting/Tests/System/Assets/config.ini
@@ -1,5 +1,2 @@
-[Overrides]
-"Targets/Controller/Hardware/SLSC/SLSC Chassis/Chassis ID" = "VS-Eco-SLSC-12001"
-
 [Properties]
-"SLSC Chassis" = "VS-Eco-SLSC-12001"
+"SLSC Chassis" = "10.2.207.133"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Use the SLSC chassis IP address, rather than the hostname.

Remove the override from the config file because it wasn't working due to the test structure.

### Why should this Pull Request be merged?

This fixes a test. Network changes have made the chassis unreachable by hostname.

### What testing has been done?

Confirmed test passes on the ATS with this change.
