### PR TITLE
Rename niveristand-slsc-switch-message-library

### DIFF
--- a/Docs/Developer Guide.md
+++ b/Docs/Developer Guide.md
@@ -14,7 +14,7 @@ The following diagram illustrates the pattern for these devices.
 
 The producer/consumer design pattern is implemented in the [Custom Device Message Library](https://github.com/ni/niveristand-custom-device-message-library). The **Custom Device Message Library** uses named message queues to send requests and receive responses. The library defines base classes for the producer, consumer, and messages. It also defines derived classes for switch consumer and switch messages.
 
-The [SLSC Switch Message Library](https://github.com/ni/niveristand-slsc-switch-message-library) overrides the switch consumer class and calls into the **SLSC Switch API** to connect and disconnect endpoints.
+The [Routing and Faulting Message Library](https://github.com/ni/niveristand-routing-and-faulting-message-library) provides implementations which override the switch consumer class and call into device drivers to connect and disconnect endpoints.
 
 The following diagram illustrates the pattern for these libraries.
 

--- a/Includes/README.md
+++ b/Includes/README.md
@@ -2,4 +2,4 @@ This directory is where external build artifacts should be copied.
 
 Two dependencies are required to build the custom devices:
 - `CDMessaging.lvlibp` from [niveristand-custom-device-message-library](https://github.com/ni/niveristand-custom-device-message-library)
-- `SLSCSwitchMessaging.lvlibp` from [niveristand-slsc-switch-message-library](https://github.com/ni/niveristand-slsc-switch-message-library)
+- `SLSCSwitchMessaging.lvlibp` from [niveristand-routing-and-faulting-message-library](https://github.com/ni/niveristand-routing-and-faulting-message-library)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 
 List<String> lvVersions = ['2017', '2018', '2019', '2020']
 
-List<String> dependencies = ['niveristand-slsc-switch-message-library']
+List<String> dependencies = ['niveristand-routing-and-faulting-message-library']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions, dependencies)
 diffPipeline(lvVersions[0])

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ LabVIEW 2017
 
 - NI-SLSC >= 19.5
 - [Custom Device Message Library](https://github.com/ni/niveristand-custom-device-message-library)
-- [SLSC Switch Message Library](https://github.com/ni/niveristand-slsc-switch-message-library)
+- [Routing and Faulting Message Library](https://github.com/ni/niveristand-routing-and-faulting-message-library)
 - [NI VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools)
 
 ## Git History & Rebasing Policy

--- a/build.toml
+++ b/build.toml
@@ -2,7 +2,7 @@
 build_output_dir = 'Source\Built'
 archive_location = '\\nirvana\Measurements\VeriStandAddons\routing_and_faulting_custom_device'
 
-[dependencies.niveristand-slsc-switch-message-library]
+[dependencies.niveristand-routing-and-faulting-message-library]
 libraries = ['CDMessaging.lvlibp', 'SLSCSwitchMessaging.lvlibp']
 copy_location = 'Includes'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Handle the rename of `niveristand-slsc-switch-message-library` by https://github.com/ni/niveristand-slsc-switch-message-library/pull/18.

### Why should this Pull Request be merged?

Tracking a dependency name change; without this the build will be broken.

### What testing has been done?

None; this change can't be easily tested without renaming the repository (or creating a duplicate).
