### PR TITLE
Build support for hardware custom device package.

### DIFF
--- a/Source/Hardware Custom Device MDK/Hardware Custom Device MDK.lvproj
+++ b/Source/Hardware Custom Device MDK/Hardware Custom Device MDK.lvproj
@@ -1,0 +1,49 @@
+﻿<?xml version='1.0' encoding='UTF-8'?>
+<Project Type="Project" LVVersion="17008000">
+	<Item Name="My Computer" Type="My Computer">
+		<Property Name="server.app.propertiesEnabled" Type="Bool">true</Property>
+		<Property Name="server.control.propertiesEnabled" Type="Bool">true</Property>
+		<Property Name="server.tcp.enabled" Type="Bool">false</Property>
+		<Property Name="server.tcp.port" Type="Int">0</Property>
+		<Property Name="server.tcp.serviceName" Type="Str">My Computer/VI Server</Property>
+		<Property Name="server.tcp.serviceName.default" Type="Str">My Computer/VI Server</Property>
+		<Property Name="server.vi.callsEnabled" Type="Bool">true</Property>
+		<Property Name="server.vi.propertiesEnabled" Type="Bool">true</Property>
+		<Property Name="specify.custom.address" Type="Bool">false</Property>
+		<Item Name="placeholder.txt" Type="Document" URL="../placeholder.txt"/>
+		<Item Name="Dependencies" Type="Dependencies"/>
+		<Item Name="Build Specifications" Type="Build">
+			<Item Name="LabVIEW API" Type="Source Distribution">
+				<Property Name="Bld_autoIncrement" Type="Bool">true</Property>
+				<Property Name="Bld_buildCacheID" Type="Str">{0DE8C8CF-7717-4B03-902F-8A32BA2DCB5F}</Property>
+				<Property Name="Bld_buildSpecName" Type="Str">LabVIEW API</Property>
+				<Property Name="Bld_excludedDirectory[0]" Type="Path">vi.lib</Property>
+				<Property Name="Bld_excludedDirectory[0].pathType" Type="Str">relativeToAppDir</Property>
+				<Property Name="Bld_excludedDirectory[1]" Type="Path">instr.lib</Property>
+				<Property Name="Bld_excludedDirectory[1].pathType" Type="Str">relativeToAppDir</Property>
+				<Property Name="Bld_excludedDirectory[2]" Type="Path">user.lib</Property>
+				<Property Name="Bld_excludedDirectory[2].pathType" Type="Str">relativeToAppDir</Property>
+				<Property Name="Bld_excludedDirectory[3]" Type="Path">resource/objmgr</Property>
+				<Property Name="Bld_excludedDirectory[3].pathType" Type="Str">relativeToAppDir</Property>
+				<Property Name="Bld_excludedDirectory[4]" Type="Path">/C/ProgramData/National Instruments/InstCache/17.0</Property>
+				<Property Name="Bld_excludedDirectory[5]" Type="Path">/C/Users/Admin/Documents/LabVIEW Data/2017(32-bit)/ExtraVILib</Property>
+				<Property Name="Bld_excludedDirectoryCount" Type="Int">6</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../builds/NI_AB_PROJECTNAME/LabVIEW API</Property>
+				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
+				<Property Name="Bld_previewCacheID" Type="Str">{6F2E517B-DEA5-4431-A49B-D206321E5189}</Property>
+				<Property Name="Bld_version.major" Type="Int">1</Property>
+				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
+				<Property Name="Destination[0].path" Type="Path">../builds/NI_AB_PROJECTNAME/LabVIEW API</Property>
+				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
+				<Property Name="Destination[1].path" Type="Path">../builds/NI_AB_PROJECTNAME/LabVIEW API/data</Property>
+				<Property Name="DestinationCount" Type="Int">2</Property>
+				<Property Name="Source[0].itemID" Type="Str">{B5927313-1649-4367-ABA5-C81ED9235961}</Property>
+				<Property Name="Source[0].type" Type="Str">Container</Property>
+				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
+				<Property Name="Source[1].itemID" Type="Ref">/My Computer/placeholder.txt</Property>
+				<Property Name="Source[1].sourceInclusion" Type="Str">Include</Property>
+				<Property Name="SourceCount" Type="Int">2</Property>
+			</Item>
+		</Item>
+	</Item>
+</Project>

--- a/build.toml
+++ b/build.toml
@@ -18,6 +18,9 @@ path = 'Source\NI-SWITCH\NI-SWITCH Custom Device.lvproj'
 [projects.examples]
 path = 'Source\Scripting Examples\Scripting Examples.lvproj'
 
+[projects.hw_mdk]
+path = 'Source\Hardware Custom Device MDK\Hardware Custom Device MDK.lvproj'
+
 [[build.steps]]
 name = 'Routing and Faulting Configuration Library'
 type = 'lvBuildSpec'
@@ -162,6 +165,14 @@ target = 'My Computer'
 build_spec = 'Examples'
 dependency_target = 'Windows'
 
+[[build.steps]]
+name = 'Hardware Custom Device API'
+type = 'lvBuildSpec'
+project = '{hw_mdk}'
+target = 'My Computer'
+build_spec = 'LabVIEW API'
+dependency_target = 'Windows'
+
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Built\Routing and Faulting'
@@ -209,6 +220,13 @@ type = 'nipkg'
 payload_dir = 'Source\Built\Scripting Examples'
 install_destination = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\Routing and Faulting'
 control_file = 'control_examples'
+package_output_dir = 'Source\Built'
+
+[[package]]
+type = 'nipkg'
+payload_dir = 'Source\Shared\Hardware Custom Device API'
+install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Routing and Faulting Hardware Custom Device MDK'
+control_file = 'control_hardware_cd_mdk'
 package_output_dir = 'Source\Built'
 
 [[package]]

--- a/control_hardware_cd_mdk
+++ b/control_hardware_cd_mdk
@@ -1,0 +1,16 @@
+Package: ni-routing-and-faulting-hardware-cd-mdk-veristand-{veristand_version}-labview-support
+Version: {nipkg_version}
+Architecture: windows_x64
+Maintainer: National Instruments <support@ni.com>
+XB-Plugin: file
+Description: Provides LabVIEW support for the Routing and Faulting Hardware Custom Device MDK for NI VeriStand {veristand_version}.
+XB-Eula: eula-ni-standard
+Priority: standard
+Homepage: http://www.ni.com
+XB-LanguageSupport: en
+XB-UserVisible: yes
+Section: Add-Ons
+XB-DisplayVersion: {display_version}
+XB-DisplayName: Routing and Faulting Hardware Custom Device MDK LabVIEW Support for VeriStand {veristand_version}
+Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common
+Recommends: ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_hardware_cd_mdk
+++ b/control_hardware_cd_mdk
@@ -3,7 +3,7 @@ Version: {nipkg_version}
 Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
-Description: Provides LabVIEW support for the Routing and Faulting Hardware Custom Device MDK for NI VeriStand {veristand_version}.
+Description: Provides support for creating Routing and Faulting Hardware Custom Devices for NI VeriStand {veristand_version}.
 XB-Eula: eula-ni-standard
 Priority: standard
 Homepage: http://www.ni.com

--- a/control_hardware_cd_mdk
+++ b/control_hardware_cd_mdk
@@ -1,4 +1,4 @@
-Package: ni-routing-and-faulting-hardware-cd-mdk-veristand-{veristand_version}-labview-support
+Package: ni-routing-and-faulting-mdk-veristand-{veristand_version}
 Version: {nipkg_version}
 Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>


### PR DESCRIPTION
Empty LV 2017 project with placeholder file
Build spec for LabVIEW API that includes placeholder for now
control file for nipkg
added project, build, and package to build.toml

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds support for building a new package, Hardware Custom Device MDK to the pipeline

### Why should this Pull Request be merged?

So that we can proceed with development on the MDK knowing that it's set up with the build pipeline

### What testing has been done?

Minimal testing, hoping to use this PR for advice on how to test this.