### PR TITLE
Add NI-SWITCH dependencies to Readmes

### DIFF
--- a/Includes/README.md
+++ b/Includes/README.md
@@ -3,3 +3,4 @@ This directory is where external build artifacts should be copied.
 Two dependencies are required to build the custom devices:
 - `CDMessaging.lvlibp` from [niveristand-custom-device-message-library](https://github.com/ni/niveristand-custom-device-message-library)
 - `SLSCSwitchMessaging.lvlibp` from [niveristand-routing-and-faulting-message-library](https://github.com/ni/niveristand-routing-and-faulting-message-library)
+- `NISWITCHMessaging.lvlibp` from [niveristand-routing-and-faulting-message-library](https://github.com/ni/niveristand-routing-and-faulting-message-library)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ LabVIEW 2017
 ## Dependencies
 
 - NI-SLSC >= 19.5
+- NI-SWITCH >= 17.0
 - [Custom Device Message Library](https://github.com/ni/niveristand-custom-device-message-library)
 - [Routing and Faulting Message Library](https://github.com/ni/niveristand-routing-and-faulting-message-library)
 - [NI VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update developers and users to the need to install a compatible version of NI-SWITCH to use all of Routing and Faulting
Update developers to add `NISWITCHMessaging.lvlibp` to the "Includes" directory

### Why should this Pull Request be merged?

Keep docs up to date

### What testing has been done?

None
