### PR TITLE
NI-SWITCH scripting errors go to the same place as the other CDs

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -214,7 +214,7 @@ package_output_dir = 'Source\Built'
 
 [package.payload_map]
 'Source\\Built\\Scripting\\NI-SWITCH' = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\NI-SWITCH'
-'Source\\Built\\Errors\\NI-SWITCH' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'
+'Source\\Built\\Errors\\NI-SWITCH' = 'ni-paths-LV{veristand_version}DIR\resource\errors\English'
 
 [[package]]
 type = 'nipkg'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix a copy-paste error for the NI-SWITCH scripting error location.

### Why should this Pull Request be merged?

The NI-SWITCH scripting package currently doesn't install errors to the same location as the other scripting packages. Found on a call with @douglasnorman.

### What testing has been done?

Relying on PR build.
