### PR TITLE
Fix recommendation

### DIFF
--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -13,4 +13,4 @@ Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}
 Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common
-Recommends: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (>= {display_version})
+Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `ni-routing-and-faulting-veristand-{veristand_version}-labview-support` to recommend the new scripting example packages.

### Why should this Pull Request be merged?

The current recommendation is broken.

### What testing has been done?

N/A
