### PR TITLE
Parent custom devices under NI in menu

### DIFF
--- a/Source/NI-SWITCH/Custom Device NI-SWITCH.xml
+++ b/Source/NI-SWITCH/Custom Device NI-SWITCH.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 	<XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
 	<AddMenu>
-		<eng>National Instruments::NI-SWITCH</eng>
-		<loc>National Instruments::NI-SWITCH</loc>
+		<eng>NI::NI-SWITCH</eng>
+		<loc>NI::NI-SWITCH</loc>
 	</AddMenu>
 	<Version>1.0.0</Version>
 	<Type>Asynchronous</Type>

--- a/Source/Routing and Faulting/Custom Device Routing and Faulting.xml
+++ b/Source/Routing and Faulting/Custom Device Routing and Faulting.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
   <XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
   <AddMenu>
-    <eng>National Instruments::Routing and Faulting</eng>
-    <loc>National Instruments::Routing and Faulting</loc>
+    <eng>NI::Routing and Faulting</eng>
+    <loc>NI::Routing and Faulting</loc>
   </AddMenu>
   <Version>1.0.0</Version>
   <Type>Asynchronous</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make the custom devices appear under the "NI" menu item, rather than "National Instruments".

### Why should this Pull Request be merged?

Branding update.

### What testing has been done?

N/A
