### PR TITLE
Install to bitness-specific locations

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -140,7 +140,7 @@ package_output_dir = 'Source\Built'
 
 [package.payload_map]
 'Source\\Built\\Routing and Faulting' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Routing and Faulting'
-'Source\\Built\\Errors\\Routing and Faulting' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'
+'Source\\Built\\Errors\\Routing and Faulting' = 'ni-paths-NISHAREDDIR{nipaths_64_bitness_suffix}\LabVIEW Run-Time\{veristand_version}\errors\English'
 
 [[package]]
 type = 'nipkg'
@@ -176,7 +176,7 @@ package_output_dir = 'Source\Built'
 
 [package.payload_map]
 'Source\\Built\\NI-SWITCH' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\NI-SWITCH'
-'Source\\Built\\Errors\\NI-SWITCH' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'
+'Source\\Built\\Errors\\NI-SWITCH' = 'ni-paths-NISHAREDDIR{nipaths_64_bitness_suffix}\LabVIEW Run-Time\{veristand_version}\errors\English'
 
 [[package]]
 type = 'nipkg'

--- a/build.toml
+++ b/build.toml
@@ -148,8 +148,8 @@ control_file = 'control_routing_faulting_scripting'
 package_output_dir = 'Source\Built'
 
 [package.payload_map]
-'Source\\Built\\Scripting\\Routing and Faulting' = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Routing and Faulting'
-'Source\\Built\\Errors\\Routing and Faulting' = 'ni-paths-LV{veristand_version}DIR\resource\errors\English'
+'Source\\Built\\Scripting\\Routing and Faulting' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\Routing and Faulting'
+'Source\\Built\\Errors\\Routing and Faulting' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\resource\errors\English'
 
 [[package]]
 type = 'nipkg'
@@ -158,7 +158,7 @@ package_output_dir = 'Source\Built'
 
 [package.payload_map]
 'Source\\Built\\SLSC Switch' = 'documents\National Instruments\NI VeriStand {veristand_version}\SLSC Plugins\Modules\SLSC Switch'
-'Source\\Built\\Errors\\SLSC Switch' = 'ni-paths-LV{veristand_version}DIR\resource\errors\English'
+'Source\\Built\\Errors\\SLSC Switch' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\resource\errors\English'
 
 [[package]]
 type = 'nipkg'
@@ -166,8 +166,8 @@ control_file = 'control_slsc_switch_scripting'
 package_output_dir = 'Source\Built'
 
 [package.payload_map]
-'Source\\Built\\Scripting\\SLSC Switch' = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\SLSC Switch'
-'Source\\Built\\Errors\\SLSC Switch' = 'ni-paths-LV{veristand_version}DIR\resource\errors\English'
+'Source\\Built\\Scripting\\SLSC Switch' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\SLSC Switch'
+'Source\\Built\\Errors\\SLSC Switch' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\resource\errors\English'
 
 [[package]]
 type = 'nipkg'
@@ -184,27 +184,27 @@ control_file = 'control_ni_switch_scripting'
 package_output_dir = 'Source\Built'
 
 [package.payload_map]
-'Source\\Built\\Scripting\\NI-SWITCH' = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\NI-SWITCH'
-'Source\\Built\\Errors\\NI-SWITCH' = 'ni-paths-LV{veristand_version}DIR\resource\errors\English'
+'Source\\Built\\Scripting\\NI-SWITCH' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\NI-SWITCH'
+'Source\\Built\\Errors\\NI-SWITCH' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\resource\errors\English'
 
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Built\SLSC Switch Scripting Examples'
-install_destination = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\SLSC Switch'
+install_destination = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\examples\NI VeriStand Custom Devices\SLSC Switch'
 control_file = 'control_slsc_switch_examples'
 package_output_dir = 'Source\Built'
 
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Built\NI-SWITCH Scripting Examples'
-install_destination = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\NI-SWITCH'
+install_destination = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\examples\NI VeriStand Custom Devices\NI-SWITCH'
 control_file = 'control_ni_switch_examples'
 package_output_dir = 'Source\Built'
 
 [[package]]
 type = 'nipkg'
 payload_dir = 'Source\Shared\Custom Device LabVIEW Common'
-install_destination = 'ni-paths-LV{veristand_version}DIR'
+install_destination = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}'
 control_file = 'control_custom_device_labview_support_common'
 package_output_dir = 'Source\Built'
 

--- a/control_custom_device_labview_support_common
+++ b/control_custom_device_labview_support_common
@@ -12,4 +12,4 @@ XB-UserVisible: no
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: VeriStand Custom Device Common Files for LabVIEW {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_custom_device_labview_support_common
+++ b/control_custom_device_labview_support_common
@@ -12,4 +12,4 @@ XB-UserVisible: no
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: VeriStand Custom Device Common Files for LabVIEW {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_ni_switch
+++ b/control_ni_switch
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI-SWITCH for VeriStand {veristand_version}
-Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-switch (>= {labview_short_version}.0.0)
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch (>= {labview_short_version}.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_ni_switch_examples
+++ b/control_ni_switch_examples
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI-SWITCH LabVIEW Examples for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-support (>= {display_version})
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-support (>= {display_version})

--- a/control_ni_switch_examples
+++ b/control_ni_switch_examples
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI-SWITCH LabVIEW Examples for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-support (>= {display_version})
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-support (>= {display_version})

--- a/control_ni_switch_scripting
+++ b/control_ni_switch_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI-SWITCH LabVIEW Support for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-switch-labview-20{labview_short_version}-support-x86 (>= {labview_short_version}.0.0), ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_ni_switch_scripting
+++ b/control_ni_switch_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI-SWITCH LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_routing_faulting
+++ b/control_routing_faulting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Routing and Faulting for VeriStand {veristand_version}
-Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)
 Recommends: ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version})

--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_slsc_switch
+++ b/control_slsc_switch
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI SLSC Switch for VeriStand {veristand_version}
-Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-slsc-switch-runtime (>= {labview_short_version}.0.0)
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-runtime (>= {labview_short_version}.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_slsc_switch_examples
+++ b/control_slsc_switch_examples
@@ -12,7 +12,7 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Examples for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version})
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version})
 Replaces: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (<< 20.6.0)
 Conflicts: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (<< 20.6.0)
 Provides: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (= 20.6.0)

--- a/control_slsc_switch_examples
+++ b/control_slsc_switch_examples
@@ -12,7 +12,7 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Examples for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version})
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version})
 Replaces: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (<< 20.6.0)
 Conflicts: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (<< 20.6.0)
 Provides: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (= 20.6.0)

--- a/control_slsc_switch_scripting
+++ b/control_slsc_switch_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Support for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-slsc-switch-labview-20{labview_short_version}-support-x86 (>= {labview_short_version}.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_slsc_switch_scripting
+++ b/control_slsc_switch_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update package installation paths and dependencies to accommodate different LabVIEW bitnesses.

### Why should this Pull Request be merged?

We are using LabVIEW 2021 64-bit.

### What testing has been done?

Inspected PR-built packages.
