### PR TITLE
Use quarterly display version, 23.0.0 common package

### DIFF
--- a/control_ni_switch
+++ b/control_ni_switch
@@ -10,7 +10,7 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI-SWITCH for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch (>= {labview_short_version}.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_ni_switch_examples
+++ b/control_ni_switch_examples
@@ -10,6 +10,6 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI-SWITCH LabVIEW Examples for VeriStand {veristand_version}
 Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-support (>= {display_version})

--- a/control_ni_switch_scripting
+++ b/control_ni_switch_scripting
@@ -10,7 +10,7 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI-SWITCH LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_routing_faulting
+++ b/control_routing_faulting
@@ -10,7 +10,7 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Routing and Faulting for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)
 Recommends: ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version})

--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -10,7 +10,7 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_slsc_switch
+++ b/control_slsc_switch
@@ -10,7 +10,7 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI SLSC Switch for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-runtime (>= {labview_short_version}.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_slsc_switch_examples
+++ b/control_slsc_switch_examples
@@ -10,7 +10,7 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Examples for VeriStand {veristand_version}
 Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version})
 Replaces: ni-routing-and-faulting-veristand-{veristand_version}-labview-examples (<< 20.6.0)

--- a/control_slsc_switch_scripting
+++ b/control_slsc_switch_scripting
@@ -10,7 +10,7 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-labview-20{labview_short_version}-support{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Use quarterly display version, and upgrade `ni-veristand-{veristand_version}-custom-device-labview-support-common` dependency to `23.0.0`.

### Why should this Pull Request be merged?

We need the newer `ni-veristand-{veristand_version}-custom-device-labview-support-common` dependency as there is not a `21.0.0` version supporting LabVIEW 2023.

### What testing has been done?

PR build.
