### PR TITLE
remove pack parameter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ stages:
 
       releaseVersion: '23.0.0'
       quarterlyReleaseVersion: '2023 Q1'
-      buildOutputLocation: 'Built'
+      buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\\Measurements\VeriStandAddons\prototype\routing_and_faulting_custom_device'
 
       packages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,6 @@ stages:
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\\Measurements\VeriStandAddons\prototype\routing_and_faulting_custom_device'
 
-      pack: true
       packages:
         - controlFileName: 'control_routing_faulting'
           payloadMaps:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

pack parameter was removed in build tools with latest updates.  build output location also fixed, that was inadvertently altered at some point.

### Why should this Pull Request be merged?

build won't run with invalid parameters.  Archive step will fail with current set up since Built is the wrong location.

### What testing has been done?

build runs