### PR TITLE
shorten payloads

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,52 +121,52 @@ stages:
       packages:
         - controlFileName: 'control_routing_faulting'
           payloadMaps:
-            - payloadLocation: 'Source\Built\Routing and Faulting'
+            - payloadLocation: 'Routing and Faulting'
               installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\Routing and Faulting'
-            - payloadLocation: 'Source\Built\Errors\Routing and Faulting'
+            - payloadLocation: 'Errors\Routing and Faulting'
               installLocation: 'ni-paths-NISHAREDDIR$(nipkgx64suffix)\LabVIEW Run-Time\$(lvVersion)\errors\English'
 
         - controlFileName: 'control_routing_faulting_scripting'
           payloadMaps:
-            - payloadLocation: 'Source\Built\Scripting\Routing and Faulting'
+            - payloadLocation: 'Scripting\Routing and Faulting'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\vi.lib\addons\VeriStand Custom Device Scripting APIs\Routing and Faulting'
-            - payloadLocation: 'Source\Built\Errors\Routing and Faulting'
+            - payloadLocation: 'Errors\Routing and Faulting'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\resource\errors\English'
 
         - controlFileName: 'control_slsc_switch'
           payloadMaps:
-            - payloadLocation: 'Source\Built\SLSC Switch'
+            - payloadLocation: 'SLSC Switch'
               installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\SLSC Plugins\Modules\SLSC Switch'
-            - payloadLocation: 'Source\Built\Errors\SLSC Switch'
+            - payloadLocation: 'Errors\SLSC Switch'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\resource\errors\English'
 
         - controlFileName: 'control_slsc_switch_scripting'
           payloadMaps:
-            - payloadLocation: 'Source\Built\Scripting\SLSC Switch'
+            - payloadLocation: 'Scripting\SLSC Switch'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\vi.lib\addons\VeriStand Custom Device Scripting APIs\SLSC Switch'
-            - payloadLocation: 'Source\Built\Errors\SLSC Switch'
+            - payloadLocation: 'Errors\SLSC Switch'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\resource\errors\English'
 
         - controlFileName: 'control_ni_switch'
           payloadMaps:
-            - payloadLocation: 'Source\Built\NI-SWITCH'
+            - payloadLocation: 'NI-SWITCH'
               installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\NI-SWITCH'
-            - payloadLocation: 'Source\Built\Errors\NI-SWITCH'
+            - payloadLocation: 'Errors\NI-SWITCH'
               installLocation: 'ni-paths-NISHAREDDIR$(nipkgx64suffix)\LabVIEW Run-Time\$(lvVersion)\errors\English'
 
         - controlFileName: 'control_ni_switch_scripting'
           payloadMaps:
-            - payloadLocation: 'Source\Built\Scripting\NI-SWITCH'
+            - payloadLocation: 'Scripting\NI-SWITCH'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\vi.lib\addons\VeriStand Custom Device Scripting APIs\NI-SWITCH'
-            - payloadLocation: 'Source\Built\Errors\NI-SWITCH'
+            - payloadLocation: 'Errors\NI-SWITCH'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\resource\errors\English'
 
         - controlFileName: 'control_slsc_switch_examples'
           payloadMaps:
-            - payloadLocation: 'Source\Built\SLSC Switch Scripting Examples'
+            - payloadLocation: 'SLSC Switch Scripting Examples'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\examples\NI VeriStand Custom Devices\SLSC Switch'
 
         - controlFileName: 'control_ni_switch_examples'
           payloadMaps:
-            - payloadLocation: 'Source\Built\NI-SWITCH Scripting Examples'
+            - payloadLocation: 'NI-SWITCH Scripting Examples'
               installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\examples\NI VeriStand Custom Devices\NI-SWITCH'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Now that we are using payloads from nirvana archives, we do not need to include the build output path.

### Why should this Pull Request be merged?

If this is not included, we will not have any payloads in the builds

### What testing has been done?

PR Build output
