### PR TITLE
Update pipeline to only run a completion trigger event when main is built

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,10 @@ resources:
   pipelines:
     - pipeline: RoutingAndFaultingMessageLibrary
       source:   ni.niveristand-routing-and-faulting-message-library
-      trigger:  true
+      trigger:  
+        branches: 
+          include:
+            - main
 
 stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Currently any build of dependent repos (messaging libraries) triggers this to be built, but it would be better if it was only the main branch.

### Why should this Pull Request be merged?

We don't need completion triggers going every time any branch is manually built.

### What testing has been done?

![image](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/assets/42351034/e3abd029-e369-4634-bb7d-2ce7dcf743a4)

SEECD, which also has completion triggers, was triggering off of non-main branches before.
This can be validated after submission by running a dependent repo build once.
