### PR TITLE
Bump custom device LabVIEW support package dependency

### DIFF
--- a/control_ni_switch_scripting
+++ b/control_ni_switch_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI-SWITCH LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch-{labview_support_package_suffix} (>= 20.0.0), ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch-{labview_support_package_suffix} (>= 20.0.0), ni-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 24.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 24.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})

--- a/control_slsc_switch_scripting
+++ b/control_slsc_switch_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-{labview_support_package_suffix} (>= 20.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-{labview_support_package_suffix} (>= 20.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 24.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump a hard-coded dependency from 23.0 to 24.0.

### Why should this Pull Request be merged?

Needed for the feed build to pass.

### What testing has been done?

PR build.

