### PR TITLE
Add localization text in niveristand-routing-and-faulting-custom-device-LabVIEW-Support

### DIFF
--- a/control_routing_faulting_scripting
+++ b/control_routing_faulting_scripting
@@ -14,3 +14,13 @@ XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}
 Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-routing-and-faulting-veristand-{veristand_version}-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 24.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})
+Description-zh-CN: 为NI VeriStand {veristand_version}提供LabVIEW对Routing and Faulting自定义设备的支持
+XB-DisplayName-zh-CN: NI Routing and Faulting LabVIEW Support for VeriStand {veristand_version}
+Description-de: Stellt LabVIEW-Unterstützung für benutzerdefinierte ”Routing and Faulting&quot;-Geräte für NI VeriStand {veristand_version} bereit.
+XB-DisplayName-de: NI Routing and Faulting - LabVIEW-Support für VeriStand {veristand_version}
+Description-fr: Fournit le support LabVIEW pour le périphérique personnalisé Routing and Faulting pour NI VeriStand {veristand_version}
+XB-DisplayName-fr: NI Routing and Faulting - Support LabVIEW pour VeriStand {veristand_version}
+Description-ja: NI VeriStand {veristand_version}用のRouting and FaultingカスタムデバイスのLabVIEWサポートを提供します。
+XB-DisplayName-ja: NI Routing and Faulting LabVIEWサポート - VeriStand {veristand_version}用
+Description-ko: NI VeriStand {veristand_version}을(를) 위한 Routing and Faulting Custom Device의 LabVIEW 지원을 제공합니다.
+XB-DisplayName-ko: NI Routing and Faulting LabVIEW 지원 - VeriStand {veristand_version} 지원


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Include high-level description of the changes in this pull request.
As part of User Story (https://ni.visualstudio.com/DevCentral/_workitems/edit/2665528/) We are trying to include localization description for Chinese, German, Japanese, French, Korean languages for different VeriStand third party products.

TODO: Justify why this contribution should be part of the project.
Taken reference from VeriStand control page (‪\argo\ni\nipkg\pool\ni-v\ni-veristand-2024\24.0.0\24.0.0.49451-0+f299\ni-veristand-2024_24.0.0.49451-0+f299_windows_x64.nipkg.control) and edited niveristand-routing-and-faulting-LabVIEW-Support control page accordingly.

TODO: Detail what testing has been done to ensure this submission meets requirements.
Testing is in progress