### PR TITLE
Add localisation text in niveristand-routing-faulting-custom-device-LabVIEW-Support   

### DIFF
--- a/control_slsc_switch_scripting
+++ b/control_slsc_switch_scripting
@@ -14,3 +14,13 @@ XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI SLSC Switch LabVIEW Support for VeriStand {veristand_version}
 Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-{labview_support_package_suffix} (>= 20.0.0), ni-slsc-switch-veristand-{veristand_version}-support (>= {display_version}), ni-routing-and-faulting-veristand-{veristand_version}-labview-support (>= {display_version}), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 24.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})
+Description-zh-CN: 为NI VeriStand {veristand_version}提供LabVIEW支持
+XB-DisplayName-zh-CN: VeriStand {veristand_version}的NI SLSC Switch LabVIEW支持
+Description-de: Stellt LabVIEW-Unterstützung für benutzerdefinierte SLSC-Switch-Geräte für NI VeriStand {veristand_version} bereit.
+XB-DisplayName-de: NI SLSC Switch - LabVIEW-Support für VeriStand {veristand_version}
+Description-fr: Fournit le support LabVIEW pour le périphérique personnalisé SLSC Switch pour NI VeriStand {veristand_version}
+XB-DisplayName-fr: NI SLSC Switch - Support LabVIEW pour VeriStand {veristand_version}
+Description-ja: NI VeriStand {veristand_version}用のSLSC SwitchカスタムデバイスのLabVIEWサポートを提供します。
+XB-DisplayName-ja: NI SLSC Switch LabVIEWサポート - VeriStand {veristand_version}用
+Description-ko: NI VeriStand {veristand_version}을(를) 위한 SLSC Switch Custom Device의 LabVIEW 지원을 제공합니다.
+XB-DisplayName-ko: NI SLSC Switch LabVIEW 지원 - VeriStand {veristand_version} 지원


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Include high-level description of the changes in this pull request.
As part of User Story (https://ni.visualstudio.com/DevCentral/_workitems/edit/2665528/) We are trying to include localization description for Chinese, German, Japanese, French, Korean languages for different VeriStand third party products.

TODO: Justify why this contribution should be part of the project.
Taken reference from VeriStand control page (‪\argo\ni\nipkg\pool\ni-v\ni-veristand-2024\24.0.0\24.0.0.49451-0+f299\ni-veristand-2024_24.0.0.49451-0+f299_windows_x64.nipkg.control) and edited niveristand-routing-and-faulting-cd-slsc-switch-LabVIEW- Suport control page accordingly.

TODO: Detail what testing has been done to ensure this submission meets requirements.
Testing is in progress
