### PR TITLE
Add localization text in niveristand-routing-and-faulting-cd-slsc-switch control page

### DIFF
--- a/control_slsc_switch
+++ b/control_slsc_switch
@@ -14,3 +14,13 @@ XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI SLSC Switch for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-slsc-switch-runtime (>= 20.0.0)
 Recommends: ni-slsc-switch-veristand-{veristand_version}-labview-support (>= {display_version}), ni-slsc-switch-veristand-{veristand_version}-labview-examples (>= {display_version})
+Description-zh-CN: 为NI VeriStand {veristand_version}提供SLSC Switch自定义设备支持
+XB-DisplayName-zh-CN: >NI SLSC Switch for VeriStand {veristand_version}
+Description-de: Stellt Unterstützung für benutzerdefinierte SLSC-Switch-Geräte für NI VeriStand {veristand_version} bereit.
+XB-DisplayName-de: NI SLSC Switch für VeriStand {veristand_version}
+Description-fr: Fournit le support pour le périphérique personnalisé SLSC Switch pour NI VeriStand {veristand_version}
+XB-DisplayName-fr: NI SLSC Switch for VeriStand {veristand_version}
+Description-ja: NI VeriStand {veristand_version}用のSLSC Switchカスタムデバイスのサポートを提供します。
+XB-DisplayName-ja: NI SLSC Switch - VeriStand {veristand_version}用
+Description-ko: NI VeriStand {veristand_version}을(를) 위한 SLSC Switch Custom Device의 지원을 제공합니다.
+XB-DisplayName-ko: NI SLSC Switch - VeriStand {veristand_version} 지원


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

TODO: Include high-level description of the changes in this pull request.
As part of User Story (https://ni.visualstudio.com/DevCentral/_workitems/edit/2665528/) We are trying to include localization description for Chinese, German, Japanese, French, Korean languages for different VeriStand third party products.

TODO: Justify why this contribution should be part of the project.
Taken reference from VeriStand control page (‪\argo\ni\nipkg\pool\ni-v\ni-veristand-2024\24.0.0\24.0.0.49451-0+f299\ni-veristand-2024_24.0.0.49451-0+f299_windows_x64.nipkg.control) and edited niveristand-routing-and-faulting-cd-slsc-switch control page accordingly.

TODO: Detail what testing has been done to ensure this submission meets requirements.
Testing is in progress